### PR TITLE
NMS-9086: Extend Import-Package to include Apache Karaf 4.X

### DIFF
--- a/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
@@ -29,6 +29,17 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!-- Extend the Karaf compatibility to include Karaf 4.X -->
+            <Import-Package>org.apache.karaf.features;version="[2.4,5)",*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.opennms.maven.plugins</groupId>
         <artifactId>features-maven-plugin</artifactId>
         <executions>

--- a/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <artifactId>org.opennms.plugin.featuremanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/README.txt
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/README.txt
@@ -13,7 +13,7 @@ mvn archetype:generate -DarchetypeCatalog=local -DarchetypeGroupId=org.opennms.p
 -Dpackage=org.opennms.plugins.myproject.packagename
  
  Where
--DarchetypeVersion=xxx is the version of this archetype (e.g. 1.0.1)
+-DarchetypeVersion=xxx is the version of this archetype (e.g. 1.0.2)
 -DgroupId=org.opennms.plugins is the maven group id of your generated project
 -DartifactId=myproject is the maven artifact id of your generated project
 -Dpackage=org.opennms.plugins.myproject.packagename is the route java package in which the generated licence artifacts will be placed

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <groupId>org.opennms.plugins</groupId>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/README.md
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/README.md
@@ -3,7 +3,7 @@ org.opennms.plugin.pluginmanager.karaf-pluginmanager
 
 To install the plugin manager stand alone in a karaf instance use the following steps.
 
-(This works based upon apache-karaf-2.4.0 - the version used in OpenNMS)
+(This works based upon apache-karaf-2.4.0 - the version used in OpenNMS Horizon 18)
 
 a) edit <karaf home>/etc/org.ops4j.pax.mvn.cfg
 
@@ -32,14 +32,14 @@ c) From the karaf consol type the following commands
 (konsol is opened by default if you start karaf using '<karaf home>/bin/karaf')
 
 ~~~~
-karaf@root>features:addurl mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.1/xml/features
+karaf@root>features:addurl mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.2/xml/features
 karaf@root> features:install org.opennms.plugin.pluginmanager.karaf-pluginmanager
 Licence Manager Starting
 Licence Manager successfully loaded licences from file=/home/admin/devel/karaf/apache-karaf-2.4.0/./etc/pluginLicenceData.xml
 Licence Manager system set to not load remote licences
 Licence Manager Started
 Plugin Manager Rest App starting.
-Registered Product Specification for productId=org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.1
+Registered Product Specification for productId=org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.2
 Plugin Manager Starting
 Plugin Manager Successfully loaded historic data from file=/home/admin/devel/karaf/apache-karaf-2.4.0/./etc/pluginManifestData.xml
 Plugin Manager Started
@@ -52,9 +52,3 @@ note that port is by default 8181 and is set in
 ~~~~
 <karaf home>/etc/org.ops4j.pax.web.cfg
 ~~~~
-
-
-
-
-
-

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <artifactId>org.opennms.plugin.pluginmanager.karaf-pluginmanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <artifactId>org.opennms.plugin.licencemanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/pluginmanager-core/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pluginmanager-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <artifactId>org.opennms.plugin.pluginmanager.pluginmanager-core</artifactId>

--- a/org.opennms.plugin.pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.opennms.plugins</groupId>
   <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>pom</packaging>
 
   <name>org.opennms.plugin.pluginmanager.parent</name>
@@ -18,8 +18,8 @@
     <vaadinVersion>7.2.7</vaadinVersion>
     <vaadin.plugin.version>7.2.7</vaadin.plugin.version>
     <vaadinExtenderVersion>1.0.0</vaadinExtenderVersion>
-    <licencemanagerVersion>1.0.1</licencemanagerVersion>
-    <featuremanagerVersion>1.0.1</featuremanagerVersion>
+    <licencemanagerVersion>${project.version}</licencemanagerVersion>
+    <featuremanagerVersion>${project.version}</featuremanagerVersion>
     <jettyVersion>8.1.10.v20130312</jettyVersion>
     <guavaVersion>17.0</guavaVersion>
     <log4j2Version>2.1</log4j2Version>
@@ -192,7 +192,7 @@
       <dependency>
         <groupId>org.apache.karaf.shell</groupId>
         <artifactId>org.apache.karaf.shell.console</artifactId>
-        <version>2.4.0</version>
+        <version>${karafVersion}</version>
       </dependency>
 
       <dependency>

--- a/org.opennms.plugin.pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pom.xml
@@ -192,7 +192,7 @@
       <dependency>
         <groupId>org.apache.karaf.shell</groupId>
         <artifactId>org.apache.karaf.shell.console</artifactId>
-        <version>2.2.11</version>
+        <version>2.4.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The autogenerated Import-Package for the featuremanager bundle is excluding any version of Karaf higher than 2.4. This patch extends it to cover 4.X.

JIRA: https://issues.opennms.org/browse/NMS-9086