### PR TITLE
NMS-9343: Fix Jersey REST apps running in Karaf 4

### DIFF
--- a/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
@@ -40,28 +40,45 @@
       </plugin>
 
       <plugin>
-        <groupId>org.opennms.maven.plugins</groupId>
-        <artifactId>features-maven-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <id>features.xml</id>
-            <phase>process-resources</phase>
+            <id>copy-resources</id>
+            <phase>generate-resources</phase>
             <goals>
-              <goal>generate-features-xml</goal>
+              <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <bundles>
-                <bundle>mvn:com.sun.jersey/jersey-server/${jerseyVersion}</bundle>
-                <bundle>mvn:com.sun.jersey/jersey-servlet/${jerseyVersion}</bundle>
-                <bundle>mvn:com.sun.jersey/jersey-core/${jerseyVersion}</bundle>
-                <bundle>mvn:com.sun.jersey/jersey-client/${jerseyVersion}</bundle>
-                <bundle>mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
-                <bundle>mvn:org.opennms.plugins/org.opennms.plugin.featuremanager/${project.version}</bundle>
-              </bundles>
-              <features>
-                <feature>http</feature>
-                <feature>http-whiteboard</feature>
-              </features>
+              <outputDirectory>${project.build.outputDirectory}/features</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/features</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.outputDirectory}/features/features.xml</file>
+                  <type>xml</type>
+                  <classifier>features</classifier>
+                </artifact>
+              </artifacts>
             </configuration>
           </execution>
         </executions>

--- a/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>org.opennms.plugin.featuremanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/featuremanager/src/main/features/features.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/src/main/features/features.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features name="org.opennms.plugin.featuremanager" xmlns="http://karaf.apache.org/xmlns/features/v1.2.0">
+    <feature name="org.opennms.plugin.featuremanager" version="${project.version}" description="org.opennms.plugin.featuremanager">
+        <feature>http</feature>
+        <feature>http-whiteboard</feature>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-server/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-servlet/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-core/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-client/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
+        <bundle>mvn:org.opennms.plugins/org.opennms.plugin.featuremanager/${project.version}</bundle>
+    </feature>
+</features>

--- a/org.opennms.plugin.pluginmanager/featuremanager/src/main/java/org/opennms/karaf/featuremgr/rest/impl/FeatureManagerRestApplication.java
+++ b/org.opennms.plugin.pluginmanager/featuremanager/src/main/java/org/opennms/karaf/featuremgr/rest/impl/FeatureManagerRestApplication.java
@@ -28,7 +28,7 @@ public class FeatureManagerRestApplication extends Application {
 	
 	public FeatureManagerRestApplication(){
 		super();
-		LOG.info("Feature Manager starting.");
+		LOG.info("Feature Manager starting");
 	}
 
 	// doing this because the com.sun.ws.rest.api.core.PackagesResourceConfig 
@@ -47,7 +47,7 @@ public class FeatureManagerRestApplication extends Application {
 	//	}
 	
 	public void destroyMethod(){
-		LOG.info("Feature Manager shutting down.");
+		LOG.info("Feature Manager shutting down");
 	}
 
 }

--- a/org.opennms.plugin.pluginmanager/featuremanager/src/main/java/org/opennms/karaf/featuremgr/rest/impl/ServiceLoader.java
+++ b/org.opennms.plugin.pluginmanager/featuremanager/src/main/java/org/opennms/karaf/featuremgr/rest/impl/ServiceLoader.java
@@ -16,17 +16,19 @@
 package org.opennms.karaf.featuremgr.rest.impl;
 
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.karaf.features.FeaturesService;
 
 
-/** used to statically pass service references to Jersey ReST classes
+/** 
+ * Used to statically pass service references to Jersey ReST classes.
  * 
  * @author cgallen
- *
  */
 public class ServiceLoader {
 
-	private static FeaturesService featuresService= null;
+	private static AtomicReference<FeaturesService> featuresService = new AtomicReference<>();
 
 	public ServiceLoader(){
 		super();
@@ -35,21 +37,20 @@ public class ServiceLoader {
 	public ServiceLoader(FeaturesService featuresService ){
 		super();
 		setFeaturesService(featuresService);
-
 	}
 
 	/**
 	 * @return the featuresService
 	 */
-	public static synchronized FeaturesService getFeaturesService() {
-		return featuresService;
+	public static FeaturesService getFeaturesService() {
+		return featuresService.get();
 	}
 
 	/**
 	 * @param featuresService the featuresService to set
 	 */
-	public static synchronized void setFeaturesService(FeaturesService featuresService) {
-		ServiceLoader.featuresService = featuresService;
+	public static void setFeaturesService(FeaturesService featuresService) {
+		ServiceLoader.featuresService.set(featuresService);
 	}
 
 }

--- a/org.opennms.plugin.pluginmanager/featuremanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,9 +1,15 @@
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-  xsi:schemaLocation="
-		http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-cm/src/main/resources/org/apache/aries/blueprint/compendium/cm/blueprint-cm-1.1.0.xsd
-		http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd
-	">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xsi:schemaLocation="
+                http://www.osgi.org/xmlns/blueprint/v1.0.0
+                http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+                http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
+                http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+">
 
   <!-- karaf features service interface -->
   <reference id="featuresService" interface="org.apache.karaf.features.FeaturesService"/>
@@ -11,13 +17,14 @@
 
   <!-- ReST Servelet configuration for jersey -->
 
-  <service interface="javax.servlet.http.HttpServlet">
+  <bean id="featureManagerRestServlet" class="com.sun.jersey.spi.container.servlet.ServletContainer">
+    <argument ref="featureManagerRestApplication" />
+  </bean>
+
+  <service interface="javax.servlet.Servlet" ref="featureManagerRestServlet">
     <service-properties>
       <entry key="alias" value="/featuremgr/rest/v1-0" />
     </service-properties>
-    <bean class="com.sun.jersey.spi.container.servlet.ServletContainer">
-      <argument ref="featureManagerRestApplication" />
-    </bean>
   </service>
 
   <bean id="featureManagerRestApplication" class="org.opennms.karaf.featuremgr.rest.impl.FeatureManagerRestApplication" destroy-method="destroyMethod"/>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/README.txt
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/README.txt
@@ -13,7 +13,7 @@ mvn archetype:generate -DarchetypeCatalog=local -DarchetypeGroupId=org.opennms.p
 -Dpackage=org.opennms.plugins.myproject.packagename
  
  Where
--DarchetypeVersion=xxx is the version of this archetype (e.g. 1.0.3)
+-DarchetypeVersion=xxx is the version of this archetype (e.g. 1.0.4)
 -DgroupId=org.opennms.plugins is the maven group id of your generated project
 -DartifactId=myproject is the maven artifact id of your generated project
 -Dpackage=org.opennms.plugins.myproject.packagename is the route java package in which the generated licence artifacts will be placed

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <groupId>org.opennms.plugins</groupId>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/README.md
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/README.md
@@ -32,14 +32,14 @@ c) From the karaf consol type the following commands
 (konsol is opened by default if you start karaf using '<karaf home>/bin/karaf')
 
 ~~~~
-karaf@root>features:addurl mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.3/xml/features
+karaf@root>features:addurl mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.4/xml/features
 karaf@root> features:install org.opennms.plugin.pluginmanager.karaf-pluginmanager
 Licence Manager Starting
 Licence Manager successfully loaded licences from file=/home/admin/devel/karaf/apache-karaf-2.4.0/./etc/pluginLicenceData.xml
 Licence Manager system set to not load remote licences
 Licence Manager Started
 Plugin Manager Rest App starting.
-Registered Product Specification for productId=org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.3
+Registered Product Specification for productId=org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.4
 Plugin Manager Starting
 Plugin Manager Successfully loaded historic data from file=/home/admin/devel/karaf/apache-karaf-2.4.0/./etc/pluginManifestData.xml
 Plugin Manager Started

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>org.opennms.plugin.pluginmanager.karaf-pluginmanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
@@ -88,27 +88,50 @@
       </plugin>
 
       <plugin>
-        <groupId>org.opennms.maven.plugins</groupId>
-        <artifactId>features-maven-plugin</artifactId>
-        <configuration>
-          <bundles>
-            <bundle>mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/${project.version}</bundle>
-            <bundle>mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.pluginmanager-core/${project.version}</bundle>
-          </bundles>
-
-          <!-- repos for licence manager and feature manager -->
-          <repositories>
-            <repository>mvn:org.opennms.plugins/org.opennms.plugin.licencemanager/${licencemanagerVersion}/xml/features</repository>
-            <repository>mvn:org.opennms.plugins/org.opennms.plugin.featuremanager/${featuremanagerVersion}/xml/features</repository>
-          </repositories>
-
-          <features>
-            <feature>org.opennms.plugin.licencemanager</feature>
-            <feature>org.opennms.plugin.featuremanager</feature>
-          </features>
-
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/features</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/features</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.outputDirectory}/features/features.xml</file>
+                  <type>xml</type>
+                  <classifier>features</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/src/main/features/features.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/src/main/features/features.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features name="org.opennms.plugin.pluginmanager.karaf-pluginmanager" xmlns="http://karaf.apache.org/xmlns/features/v1.2.0">
+    <repository>mvn:org.opennms.plugins/org.opennms.plugin.licencemanager/${project.version}/xml/features</repository>
+    <repository>mvn:org.opennms.plugins/org.opennms.plugin.featuremanager/${project.version}/xml/features</repository>
+    <feature name="org.opennms.plugin.pluginmanager.karaf-pluginmanager" version="${project.version}" description="org.opennms.plugin.pluginmanager.karaf-pluginmanager">
+        <details>Feature for running the OSGi plugin manager in a standalone Karaf instance.</details>
+        <feature>org.opennms.plugin.licencemanager</feature>
+        <feature>org.opennms.plugin.featuremanager</feature>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-server/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-servlet/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-core/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-client/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
+        <bundle dependency="true">mvn:com.vaadin/vaadin-client/${vaadinVersion}</bundle>
+        <bundle dependency="true">mvn:com.vaadin/vaadin-client-compiled/${vaadinVersion}</bundle>
+        <bundle dependency="true">mvn:com.vaadin/vaadin-server/${vaadinVersion}</bundle>
+        <bundle dependency="true">mvn:com.vaadin/vaadin-shared/${vaadinVersion}</bundle>
+        <bundle dependency="true">mvn:com.vaadin/vaadin-shared-deps/1.0.2</bundle>
+        <bundle dependency="true">mvn:com.vaadin/vaadin-themes/${vaadinVersion}</bundle>
+        <bundle dependency="true">mvn:com.vaadin.external.json/json/0.0.20080701</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty.orbit/javax.servlet/3.0.0.v201112011016</bundle>
+        <bundle dependency="true">mvn:org.jsoup/jsoup/1.7.2</bundle>
+        <bundle dependency="true">mvn:org.opennms.vaadin-extender/service/${vaadinExtenderVersion}</bundle>
+        <bundle>mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/${project.version}</bundle>
+        <bundle>mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.pluginmanager-core/${project.version}</bundle>
+    </feature>
+</features>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,10 +1,15 @@
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-  xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 
-					http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-					http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 
-					https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-cm/src/main/resources/org/apache/aries/blueprint/compendium/cm/blueprint-cm-1.1.0.xsd
-					http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 
-					https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xsi:schemaLocation="
+                http://www.osgi.org/xmlns/blueprint/v1.0.0
+                http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+                http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
+                http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+">
 
   <!-- register product information with product registry in licence manager-->
   <reference id="productRegister" interface="org.opennms.karaf.productpub.ProductRegister" timeout="10000" />
@@ -14,16 +19,17 @@
     <property name="productPublisher" ref="productRegister"></property>
     <property name="productMetadataUri" value="/productSpec.xml"></property>
   </bean>
-  
+
   <!-- configure the rest service for plugin manager -->
-  <!-- ReST Servelet configuration for jersey -->
-  <service interface="javax.servlet.http.HttpServlet">
+  <!-- ReST Servlet configuration for jersey -->
+  <bean id="pluginManagerRestServlet" class="com.sun.jersey.spi.container.servlet.ServletContainer">
+    <argument ref="pluginManagerRestApplication" />
+  </bean>
+
+  <service interface="javax.servlet.Servlet" ref="pluginManagerRestServlet">
     <service-properties>
       <entry key="alias" value="/pluginmgr/rest/v1-0" />
     </service-properties>
-    <bean class="com.sun.jersey.spi.container.servlet.ServletContainer">
-      <argument ref="pluginManagerRestApplication" />
-    </bean>
   </service>
 
   <bean id="pluginManagerRestApplication" class="org.opennms.features.pluginmgr.rest.impl.PluginManagerRestApplication" destroy-method="destroyMethod"/>

--- a/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>org.opennms.plugin.licencemanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
@@ -40,34 +40,49 @@
       </plugin>
 
       <plugin>
-        <groupId>org.opennms.maven.plugins</groupId>
-        <artifactId>features-maven-plugin</artifactId>
-        <version>1.2.0</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <id>features.xml</id>
-            <phase>process-resources</phase>
+            <id>copy-resources</id>
+            <phase>generate-resources</phase>
             <goals>
-              <goal>generate-features-xml</goal>
+              <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <bundles>
-                <bundle>mvn:com.sun.jersey/jersey-server/${jerseyVersion}</bundle>
-                <bundle>mvn:com.sun.jersey/jersey-servlet/${jerseyVersion}</bundle>
-                <bundle>mvn:com.sun.jersey/jersey-core/${jerseyVersion}</bundle>
-                <bundle>mvn:com.sun.jersey/jersey-client/${jerseyVersion}</bundle>
-                <bundle>mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
-                <bundle>mvn:org.opennms.plugins/org.opennms.plugin.licencemanager/${project.version}</bundle>
-              </bundles>
-              <features>
-                <feature>http</feature>
-                <feature>http-whiteboard</feature>
-              </features>
+              <outputDirectory>${project.build.outputDirectory}/features</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/features</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.outputDirectory}/features/features.xml</file>
+                  <type>xml</type>
+                  <classifier>features</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/org.opennms.plugin.pluginmanager/licencemanager/src/main/features/features.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/src/main/features/features.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features name="org.opennms.plugin.licencemanager" xmlns="http://karaf.apache.org/xmlns/features/v1.2.0">
+    <feature name="org.opennms.plugin.licencemanager" version="${project.version}" description="org.opennms.plugin.licencemanager">
+        <feature>http</feature>
+        <feature>http-whiteboard</feature>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-server/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-servlet/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-core/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:com.sun.jersey/jersey-client/${jerseyVersion}</bundle>
+        <bundle dependency="true" start-level="50">mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
+        <bundle>mvn:org.opennms.plugins/org.opennms.plugin.licencemanager/${project.version}</bundle>
+    </feature>
+</features>

--- a/org.opennms.plugin.pluginmanager/licencemanager/src/main/java/org/opennms/karaf/licencemgr/rest/impl/LicenceManagerRestApplication.java
+++ b/org.opennms.plugin.pluginmanager/licencemanager/src/main/java/org/opennms/karaf/licencemgr/rest/impl/LicenceManagerRestApplication.java
@@ -20,12 +20,17 @@ import java.util.Set;
 
 import javax.ws.rs.core.Application;
 
-import org.opennms.karaf.licencemgr.rest.LicencePublisherRest;
-import org.opennms.karaf.licencemgr.rest.LicenceServiceRest;
-import org.opennms.karaf.licencemgr.rest.ProductPublisherRest;
-import org.opennms.karaf.licencemgr.rest.ProductRegisterRest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LicenceManagerRestApplication extends Application {
+
+	private static final Logger LOG = LoggerFactory.getLogger(LicenceManagerRestApplication.class);
+	
+	public LicenceManagerRestApplication() {
+		super();
+		LOG.info("Licence Manager starting");
+	}
 
 	// doing this because the com.sun.ws.rest.api.core.PackagesResourceConfig 
 	// class contains OSGi unfriendly classloader code
@@ -45,4 +50,7 @@ public class LicenceManagerRestApplication extends Application {
 	// registerInstances(new LoggingFilter(Logger.getLogger(EventGatewayApplication.class.getName()), true));
 	//	}
 
+	public void destroyMethod(){
+		LOG.info("Licence Manager shutting down");
+	}
 }

--- a/org.opennms.plugin.pluginmanager/licencemanager/src/main/java/org/opennms/karaf/licencemgr/rest/impl/ServiceLoader.java
+++ b/org.opennms.plugin.pluginmanager/licencemanager/src/main/java/org/opennms/karaf/licencemgr/rest/impl/ServiceLoader.java
@@ -15,6 +15,8 @@
 
 package org.opennms.karaf.licencemgr.rest.impl;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.opennms.karaf.licencemgr.LicenceService;
 import org.opennms.karaf.licencepub.LicencePublisher;
 import org.opennms.karaf.productpub.ProductPublisher;
@@ -27,13 +29,13 @@ import org.opennms.karaf.productpub.ProductRegister;
  */
 public class ServiceLoader {
 
-	private static LicenceService licenceService= null;
+	private static AtomicReference<LicenceService> licenceService = new AtomicReference<>();
 
-	private static LicencePublisher licencePublisher= null;
+	private static AtomicReference<LicencePublisher> licencePublisher= new AtomicReference<>();
 
-	private static ProductPublisher productPublisher= null;
+	private static AtomicReference<ProductPublisher> productPublisher= new AtomicReference<>();
 
-	private static ProductRegister productRegister= null;
+	private static AtomicReference<ProductRegister> productRegister= new AtomicReference<>();
 
 
 	public ServiceLoader(){
@@ -55,57 +57,57 @@ public class ServiceLoader {
 	/**
 	 * @return the licenceService
 	 */
-	public static synchronized LicenceService getLicenceService() {
-		return licenceService;
+	public static LicenceService getLicenceService() {
+		return licenceService.get();
 	}
 
 	/**
 	 * @param licenceService the licenceService to set
 	 */
-	public static synchronized void setLicenceService(LicenceService licenceService) {
-		ServiceLoader.licenceService = licenceService;
+	public static void setLicenceService(LicenceService licenceService) {
+		ServiceLoader.licenceService.set(licenceService);
 	}
 
 	/**
 	 * @return the licencePublisher
 	 */
-	public static synchronized LicencePublisher getLicencePublisher() {
-		return licencePublisher;
+	public static LicencePublisher getLicencePublisher() {
+		return licencePublisher.get();
 	}
 
 	/**
 	 * @param licencePublisher the licencePublisher to set
 	 */
-	public static synchronized void setLicencePublisher(LicencePublisher licencePublisher) {
-		ServiceLoader.licencePublisher = licencePublisher;
+	public static void setLicencePublisher(LicencePublisher licencePublisher) {
+		ServiceLoader.licencePublisher.set(licencePublisher);
 	}
 
 	/**
 	 * @return the productPublisher
 	 */
-	public static synchronized ProductPublisher getProductPublisher() {
-		return productPublisher;
+	public static ProductPublisher getProductPublisher() {
+		return productPublisher.get();
 	}
 
 	/**
 	 * @param productPublisher the productPublisher to set
 	 */
-	public static synchronized void setProductPublisher(ProductPublisher productPublisher) {
-		ServiceLoader.productPublisher = productPublisher;
+	public static void setProductPublisher(ProductPublisher productPublisher) {
+		ServiceLoader.productPublisher.set(productPublisher);
 	}
 
 	/**
 	 * @return the productRegister
 	 */
-	public static synchronized ProductRegister getProductRegister() {
-		return productRegister;
+	public static ProductRegister getProductRegister() {
+		return productRegister.get();
 	}
 
 	/**
 	 * @param productRegister the productRegister to set
 	 */
-	public static synchronized void setProductRegister(ProductRegister productRegister) {
-		ServiceLoader.productRegister = productRegister;
+	public static void setProductRegister(ProductRegister productRegister) {
+		ServiceLoader.productRegister.set(productRegister);
 	}
 
 }

--- a/org.opennms.plugin.pluginmanager/licencemanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,13 +13,18 @@
 <!-- See the License for the specific language governing permissions and -->
 <!-- limitations under the License. -->
 
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-  xsi:schemaLocation="
-		http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-cm/src/main/resources/org/apache/aries/blueprint/compendium/cm/blueprint-cm-1.1.0.xsd
-		http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd
-	">
-
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xsi:schemaLocation="
+                http://www.osgi.org/xmlns/blueprint/v1.0.0
+                http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+                http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
+                http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+">
 
   <!-- load default properties from  org.opennms.features.licencemgr.config.cfg if exists -->
   <cm:property-placeholder persistent-id="org.opennms.features.licencemgr.config" update-strategy="reload">
@@ -194,18 +199,19 @@
     </command>
   </command-bundle>
 
-  <!-- ReST Servelet configuration -->
+  <!-- ReST Servlet configuration -->
 
-  <service interface="javax.servlet.http.HttpServlet">
+  <bean id="licenceManagerRestServlet" class="com.sun.jersey.spi.container.servlet.ServletContainer">
+    <argument ref="licenceManagerRestApplication" />
+  </bean>
+
+  <service interface="javax.servlet.Servlet" ref="licenceManagerRestServlet">
     <service-properties>
       <entry key="alias" value="/licencemgr/rest/v1-0" />
     </service-properties>
-    <bean class="com.sun.jersey.spi.container.servlet.ServletContainer">
-      <argument ref="licenceManagerRestApplication" />
-    </bean>
   </service>
 
-  <bean id="licenceManagerRestApplication" class="org.opennms.karaf.licencemgr.rest.impl.LicenceManagerRestApplication" />
+  <bean id="licenceManagerRestApplication" class="org.opennms.karaf.licencemgr.rest.impl.LicenceManagerRestApplication" destroy-method="destroyMethod"/>
 
   <!-- ServiceLoader(LicenceService licenceService, LicencePublisher licencePublisher, ProductPublisher productPublisher, ProductRegister productRegister ) -->
   <bean id="serviceLoader" class="org.opennms.karaf.licencemgr.rest.impl.ServiceLoader">

--- a/org.opennms.plugin.pluginmanager/pluginmanager-core/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pluginmanager-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>org.opennms.plugin.pluginmanager.pluginmanager-core</artifactId>

--- a/org.opennms.plugin.pluginmanager/pluginmanager-core/src/main/java/org/opennms/features/pluginmgr/rest/impl/PluginManagerRestApplication.java
+++ b/org.opennms.plugin.pluginmanager/pluginmanager-core/src/main/java/org/opennms/features/pluginmgr/rest/impl/PluginManagerRestApplication.java
@@ -28,8 +28,7 @@ public class PluginManagerRestApplication extends Application {
 	
 	public PluginManagerRestApplication(){
 		super();
-		System.out.println("Plugin Manager Rest App starting.");
-		LOG.info("Plugin Manager Rest App starting.");
+		LOG.info("Plugin Manager REST Application starting");
 	}
 
 	// doing this because the com.sun.ws.rest.api.core.PackagesResourceConfig 
@@ -48,8 +47,7 @@ public class PluginManagerRestApplication extends Application {
 	//	}
 	
 	public void destroyMethod(){
-		System.out.println("Plugin Manager Rest App  shutting down.");
-		LOG.info("Plugin Manager Rest App  shutting down.");
+		LOG.info("Plugin Manager REST Application shutting down");
 	}
 
 }

--- a/org.opennms.plugin.pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.opennms.plugins</groupId>
   <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>pom</packaging>
 
   <name>org.opennms.plugin.pluginmanager.parent</name>

--- a/org.opennms.plugin.pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.surefire.plugin.version>2.15</maven.surefire.plugin.version>
-    <jerseyVersion>1.19</jerseyVersion>
+    <jerseyVersion>1.19.3</jerseyVersion>
     <vaadinVersion>7.2.7</vaadinVersion>
     <vaadin.plugin.version>7.2.7</vaadin.plugin.version>
     <vaadinExtenderVersion>1.0.0</vaadinExtenderVersion>


### PR DESCRIPTION
The Jersey REST applications are not reliably loading in Karaf due to a race condition between the bundle startups for the Jersey bundles and the REST service bundles.

To ensure that Jersey starts up first, I've moved the ```start-level``` for the Jersey bundles down to level ```50``` so that they will start before the REST services.

This branch also contains some minor cleanup.

* JIRA: https://issues.opennms.org/browse/NMS-9343