### PR TITLE
NMS-9363: Use 'auto-export' for DefaultResourceMapper beans

### DIFF
--- a/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
   </parent>
 
   <artifactId>org.opennms.plugin.featuremanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/featuremanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/org.opennms.plugin.pluginmanager/featuremanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -40,6 +40,6 @@
     <property name="path" value="/diagnostics" />
   </bean>
 
-  <service id="testResources" ref="testResourceMapping" interface="org.ops4j.pax.web.extender.whiteboard.ResourceMapping" />
+  <service id="testResources" ref="testResourceMapping" auto-export="interfaces" />
 
 </blueprint>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/README.txt
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/README.txt
@@ -13,7 +13,7 @@ mvn archetype:generate -DarchetypeCatalog=local -DarchetypeGroupId=org.opennms.p
 -Dpackage=org.opennms.plugins.myproject.packagename
  
  Where
--DarchetypeVersion=xxx is the version of this archetype (e.g. 1.0.4)
+-DarchetypeVersion=xxx is the version of this archetype (e.g. 1.0.5)
 -DgroupId=org.opennms.plugins is the maven group id of your generated project
 -DartifactId=myproject is the maven artifact id of your generated project
 -Dpackage=org.opennms.plugins.myproject.packagename is the route java package in which the generated licence artifacts will be placed

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager-archetype/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
   </parent>
 
   <groupId>org.opennms.plugins</groupId>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/README.md
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/README.md
@@ -32,14 +32,14 @@ c) From the karaf consol type the following commands
 (konsol is opened by default if you start karaf using '<karaf home>/bin/karaf')
 
 ~~~~
-karaf@root>features:addurl mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.4/xml/features
+karaf@root>features:addurl mvn:org.opennms.plugins/org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.5/xml/features
 karaf@root> features:install org.opennms.plugin.pluginmanager.karaf-pluginmanager
 Licence Manager Starting
 Licence Manager successfully loaded licences from file=/home/admin/devel/karaf/apache-karaf-2.4.0/./etc/pluginLicenceData.xml
 Licence Manager system set to not load remote licences
 Licence Manager Started
 Plugin Manager Rest App starting.
-Registered Product Specification for productId=org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.4
+Registered Product Specification for productId=org.opennms.plugin.pluginmanager.karaf-pluginmanager/1.0.5
 Plugin Manager Starting
 Plugin Manager Successfully loaded historic data from file=/home/admin/devel/karaf/apache-karaf-2.4.0/./etc/pluginManifestData.xml
 Plugin Manager Started

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
   </parent>
 
   <artifactId>org.opennms.plugin.pluginmanager.karaf-pluginmanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/karaf-pluginmanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/org.opennms.plugin.pluginmanager/karaf-pluginmanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -138,7 +138,7 @@
     <property name="path" value="/diagnostics" />
   </bean>
 
-  <service id="testResources" ref="testResourceMapping" interface="org.ops4j.pax.web.extender.whiteboard.ResourceMapping" />
+  <service id="testResources" ref="testResourceMapping" auto-export="interfaces" />
 
   <!-- load default properties from  org.opennms.features.pluginmgr.config.cfg if exists -->
   <cm:property-placeholder persistent-id="org.opennms.features.pluginmgr.config" update-strategy="reload">

--- a/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
   </parent>
 
   <artifactId>org.opennms.plugin.licencemanager</artifactId>

--- a/org.opennms.plugin.pluginmanager/licencemanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/org.opennms.plugin.pluginmanager/licencemanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -227,7 +227,7 @@
     <property name="path" value="/diagnostics" />
   </bean>
 
-  <service id="testResources" ref="testResourceMapping" interface="org.ops4j.pax.web.extender.whiteboard.ResourceMapping" />
+  <service id="testResources" ref="testResourceMapping" auto-export="interfaces" />
 
 
 </blueprint>

--- a/org.opennms.plugin.pluginmanager/pluginmanager-core/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pluginmanager-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
   </parent>
 
   <artifactId>org.opennms.plugin.pluginmanager.pluginmanager-core</artifactId>

--- a/org.opennms.plugin.pluginmanager/pom.xml
+++ b/org.opennms.plugin.pluginmanager/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.opennms.plugins</groupId>
   <artifactId>org.opennms.plugin.pluginmanager.parent</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <packaging>pom</packaging>
 
   <name>org.opennms.plugin.pluginmanager.parent</name>


### PR DESCRIPTION
Instead of specifying the Pax Web 4 interface, just let the resources auto-export. This allows compatibility with Pax Web 6 where the interface name has changed.

JIRA: https://issues.opennms.org/browse/NMS-9363